### PR TITLE
added alessio/shellescape and changed prepareEnvs to use envfile

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.22
 toolchain go1.22.4
 
 require (
+	al.essio.dev/pkg/shellescape v1.5.0
 	github.com/alexellis/go-execute v0.6.0
 	github.com/containerd/containerd v1.7.6
 	github.com/intertwin-eu/interlink v0.0.0-20240829090340-24c45973f3ec

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+al.essio.dev/pkg/shellescape v1.5.0 h1:7oTvSsQ5kg9WksA9O58y9wjYnY4jP0CL82/Q8WLUGKk=
+al.essio.dev/pkg/shellescape v1.5.0/go.mod h1:6sIqp7X2P6mThCQ7twERpZTuigpr6KbZWtls1U8I890=
 github.com/alexellis/go-execute v0.6.0 h1:FVGoudJnWSObwf9qmehbvVuvhK6g1UpKOCBjS+OUXEA=
 github.com/alexellis/go-execute v0.6.0/go.mod h1:nlg2F6XdYydUm1xXQMMiuibQCV1mveybBkNWfdNznjk=
 github.com/cenkalti/backoff/v4 v4.3.0 h1:MyRJ/UdXutAwSAT+s3wNd7MfTIcy71VQueUuFK343L8=

--- a/pkg/slurm/Create.go
+++ b/pkg/slurm/Create.go
@@ -81,7 +81,7 @@ func (h *SidecarHandler) SubmitHandler(w http.ResponseWriter, r *http.Request) {
 
 		commstr1 := []string{"singularity", "exec", "--containall", "--nv", singularityMounts, singularityOptions}
 
-		envs := prepareEnvs(spanCtx, container)
+		envs := prepareEnvs(spanCtx, h.Config, data, container)
 		image := ""
 
 		CPULimit, _ := container.Resources.Limits.Cpu().AsInt64()


### PR DESCRIPTION
Fixes #27

STATUS: READY for code review and merge

<!--
A good PR should describe what benefit this brings to the repository.
Ideally, there is an existing issue which the PR address.

Please check the Contributing guide CONTRIBUTING.md for style requirements and
advice.
-->

# Summary

<!-- Describe in plain English what this PR does -->
Fixes #27 by moving all env variables to inside a envfile.properties, which fixes the file command limit of 4096 characters, and bash-quoting it, which fixes all quote issues.
This does not fix the missing prefix `docker:/docker.io/`

This has not been tested yet. The CI/CD gives some error:  https://github.com/antoinetran/interlink-slurm-plugin/actions for lint and build. This is my first time programming in GO, and I don't understand why the branch has issue with lint ([clone ](https://github.com/antoinetran/interlink-slurm-plugin/actions/runs/11219763900) , which has nothing to do with the modifications I did).

The docker builds fails too, https://github.com/antoinetran/interlink-slurm-plugin/actions/runs/11219763886 , because I did not modify the go.sum . Will do it now.

---

<!-- Add, if any, the related issue here, e.g. #6 -->

**Related issue :**
#27