### PR TITLE
Fixes #27: regression fix of envfile.properties parent folder created

### DIFF
--- a/pkg/slurm/Create.go
+++ b/pkg/slurm/Create.go
@@ -81,7 +81,6 @@ func (h *SidecarHandler) SubmitHandler(w http.ResponseWriter, r *http.Request) {
 
 		commstr1 := []string{"singularity", "exec", "--containall", "--nv", singularityMounts, singularityOptions}
 
-		envs := prepareEnvs(spanCtx, h.Config, data, container)
 		image := ""
 
 		CPULimit, _ := container.Resources.Limits.Cpu().AsInt64()
@@ -107,6 +106,9 @@ func (h *SidecarHandler) SubmitHandler(w http.ResponseWriter, r *http.Request) {
 			os.RemoveAll(filesPath)
 			return
 		}
+		
+		// prepareEnvs creates a file in the working directory, that must exist. This is created at prepareMounts.
+		envs := prepareEnvs(spanCtx, h.Config, data, container)
 
 		image = container.Image
 		if image_uri, ok := metadata.Annotations["slurm-job.vk.io/image-root"]; ok {


### PR DESCRIPTION
before

<!--
A good PR should describe what benefit this brings to the repository.
Ideally, there is an existing issue which the PR address.

Please check the Contributing guide CONTRIBUTING.md for style requirements and
advice.
-->

# Summary

<!-- Describe in plain English what this PR does -->
Fix regression introduced by https://github.com/interTwin-eu/interlink-slurm-plugin/pull/29 , because the parent directory does not exist for envfile.properties to be created. The directory is now created because the prepareMount create the directory, and only then the envfile.properties is created.
---

<!-- Add, if any, the related issue here, e.g. #6 -->

**Related issue :**
