### PR TITLE
Fix issue45 - support for serviceAccount in slurm jobs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,10 @@ go 1.22
 
 toolchain go1.22.4
 
+//replace github.com/intertwin-eu/interlink => C:\Users\username\Custom\data\git\interlink
+// TODO: to be replaced when a proper tag is done in github.com/intertwin-eu/interlink
+replace github.com/intertwin-eu/interlink v0.0.0-20240829090340-24c45973f3ec => github.com/antoinetran/interlink v0.3.7-patchI45V034
+
 require (
 	al.essio.dev/pkg/shellescape v1.5.0
 	github.com/alexellis/go-execute v0.6.0

--- a/pkg/slurm/Create.go
+++ b/pkg/slurm/Create.go
@@ -89,7 +89,8 @@ func (h *SidecarHandler) SubmitHandler(w http.ResponseWriter, r *http.Request) {
 			singularityCommand = "run"
 		}
 
-		commstr1 := []string{"singularity", singularityCommand, "--containall", "--nv", singularityMounts, singularityOptions}
+		// no-eval is important so that singularity does not evaluate env var, because the shellquote has already done the safety check.
+		commstr1 := []string{"singularity", singularityCommand, "--no-eval", "--containall", "--nv", singularityMounts, singularityOptions}
 
 		image := ""
 

--- a/pkg/slurm/Create.go
+++ b/pkg/slurm/Create.go
@@ -109,7 +109,7 @@ func (h *SidecarHandler) SubmitHandler(w http.ResponseWriter, r *http.Request) {
 			resourceLimits.Memory += MemoryLimit
 		}
 
-		mounts, err := prepareMounts(spanCtx, h.Config, data, container, filesPath)
+		mounts, err := prepareMounts(spanCtx, h.Config, &data, &container, filesPath)
 		log.G(h.Ctx).Debug(mounts)
 		if err != nil {
 			statusCode = http.StatusInternalServerError

--- a/pkg/slurm/GetLogs.go
+++ b/pkg/slurm/GetLogs.go
@@ -195,8 +195,10 @@ func (h *SidecarHandler) GetLogsHandler(w http.ResponseWriter, r *http.Request) 
 	containerOutputPath := path + "/" + req.ContainerName + ".out"
 	var output []byte
 	if req.Opts.Timestamps {
-		h.logErrorVerbose(sessionContextMessage+"unsupported option req.Opts.Timestamps", spanCtx, w, err)
-		return
+		//h.logErrorVerbose(sessionContextMessage+"unsupported option req.Opts.Timestamps, ignoring it", spanCtx, w, err)
+		// TODO: support for timestamps.
+		log.G(h.Ctx).Warning(sessionContextMessage, "unsupported option req.Opts.Timestamps, ignoring it")
+		//return
 	}
 	containerOutput, err := h.ReadLogs(containerOutputPath, span, spanCtx, w, sessionContextMessage)
 	if err != nil {


### PR DESCRIPTION
<!--
A good PR should describe what benefit this brings to the repository.
Ideally, there is an existing issue which the PR address.

Please check the Contributing guide CONTRIBUTING.md for style requirements and
advice.
-->

# Summary

<!-- Describe in plain English what this PR does -->

This add partial supports to Projected Volume, in particular for those used for Service Accounts.
Also fix shellquote with `no-eval` in singularity default argument.
Also fix multi-container in one pod support (it was not run in parallel until now).
Also workaround of TimeStamps support: now it throw a warning, but still output logs instead of crashing.
---

<!-- Add, if any, the related issue here, e.g. #6 -->

**Related issue :**
https://github.com/interTwin-eu/interlink-slurm-plugin/issues/45
https://github.com/interTwin-eu/interlink-slurm-plugin/discussions/46
https://github.com/interTwin-eu/interlink-slurm-plugin/issues/47
https://github.com/interTwin-eu/interlink-slurm-plugin/issues/48