### PR TITLE
fix #30 image prefix docker:// - replaced SingularityPrefix to

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ SbatchPath: "/usr/bin/sbatch"
 ScancelPath: "/usr/bin/scancel"
 SqueuePath: "/usr/bin/squeue"
 CommandPrefix: ""
-SingularityPrefix: ""
+ImagePrefix: ""
 ExportPodData: true
 DataRootFolder: ".local/interlink/jobs/"
 Namespace: "vk"
@@ -133,6 +133,7 @@ building the docker image (`docker compose up -d --build --force-recreate` will 
 | SbatchPath | path to your Slurm's sbatch binary |
 | ScancelPath | path to your Slurm's scancel binary |
 | CommandPrefix | here you can specify a prefix for the programmatically generated script (for the slurm plugin). Basically, if you want to run anything before the script itself, put it here. |
+| ImagePrefix | here you can specify a prefix if you want to prefix the container image name. For example: "docker://". This will do something only if the prefix is not added yet, and if there is no "/" as the first letter of the image name (e.g.: "/root/image.tgz"), which would be an absolute path. Warning: using this field will not allow relative path anymore (e.g.: ./image.tgz and ImagePrefix set to "docker://" will generate "docker://./image.tgz instead of relative path. Use absolute path instead of relative path). Warning2: the the container annotation "slurm-job.vk.io/image-root" is set, this take precedence over ImagePrefix.|
 | ExportPodData | Set it to true if you want to export Pod's ConfigMaps and Secrets as mountpoints in your Singularity Container |
 | DataRootFolder | Specify where to store the exported ConfigMaps/Secrets locally |
 | Namespace | Namespace where Pods in your K8S will be registered |

--- a/examples/config/SlurmConfig.yaml
+++ b/examples/config/SlurmConfig.yaml
@@ -4,7 +4,7 @@ SbatchPath: "/usr/bin/sbatch"
 ScancelPath: "/usr/bin/scancel"
 SqueuePath: "/usr/bin/squeue"
 CommandPrefix: ""
-SingularityPrefix: ""
+ImagePrefix: "docker://"
 ExportPodData: true
 DataRootFolder: ".local/interlink/jobs/"
 Namespace: "vk"

--- a/pkg/slurm/types.go
+++ b/pkg/slurm/types.go
@@ -10,6 +10,7 @@ type SlurmConfig struct {
 	Socket            string `yaml:"Socket"`
 	ExportPodData     bool   `yaml:"ExportPodData"`
 	Commandprefix     string `yaml:"CommandPrefix"`
+	ImagePrefix       string `yaml:"ImagePrefix"`
 	DataRootFolder    string `yaml:"DataRootFolder"`
 	Namespace         string `yaml:"Namespace"`
 	Tsocks            bool   `yaml:"Tsocks"`
@@ -18,7 +19,6 @@ type SlurmConfig struct {
 	BashPath          string `yaml:"BashPath"`
 	VerboseLogging    bool   `yaml:"VerboseLogging"`
 	ErrorsOnlyLogging bool   `yaml:"ErrorsOnlyLogging"`
-	SingularityPrefix string `yaml:"SingularityPrefix"`
 	set               bool
 }
 


### PR DESCRIPTION
ImagePrefix

<!--
A good PR should describe what benefit this brings to the repository.
Ideally, there is an existing issue which the PR address.

Please check the Contributing guide CONTRIBUTING.md for style requirements and
advice.
-->

# Summary

<!-- Describe in plain English what this PR does -->

Replaced SingularityPrefix, which was not used at all in the code, except in Slurm configuration, by ImagePrefix.
ImagePrefix is an optional configuration. When set, it will be added as prefix in the image name.
If the image name contains "/", nothing is done.
Otherwise, the imagePrefix in configuration (or in annotation by the usual `slurm-job.vk.io/image-root` is used). The annotation takes precedence over the configuration. If the image name already contains the prefix, nothing is done.
---

<!-- Add, if any, the related issue here, e.g. #6 -->

**Related issue :**
https://github.com/interTwin-eu/interlink-slurm-plugin/issues/30