### PR TITLE
Fix subPath handling in mountDataSimpleVolume to bind files instead of directories

### DIFF
--- a/pkg/slurm/prepare.go
+++ b/pkg/slurm/prepare.go
@@ -952,7 +952,7 @@ func mountDataSimpleVolume(
 			containerPath = filepath.Join(volumeMount.MountPath, key)
 		}
 
-		bind := fullPath + ":" + x	 + mode + " "
+		bind := fullPath + ":" + containerPath + mode + " "
 		volumesHostToContainerPaths = append(volumesHostToContainerPaths, bind)
 
 		if os.Getenv("SHARED_FS") != "true" {


### PR DESCRIPTION
This patch addresses an issue where volumes with a specified subPath were being mounted as directories rather than individual files. 
Now, when volumeMount.SubPath is set, the code will: 
- Bind the specific file at podVolumeDir/<subPath> directly to the target mountPath inside the container. 
- Continue to bind the entire directory when no subPath is provided.