### PR TITLE
Run SLURM jobs with custom GID

### DIFF
--- a/docker/SlurmConfig.yaml
+++ b/docker/SlurmConfig.yaml
@@ -21,9 +21,10 @@ EnrootDefaultOptions: ["--rw"]
 EnrootPrefix: ""
 EnrootPath: enroot
 
-# GID (Group ID) configuration - set the group ID for SLURM jobs
-# DefaultGID: 1000                # Optional: Set a default GID for all jobs
-# AllowGIDOverride: true          # Optional: Allow pods to override GID via annotation
+# UID (User ID) configuration - set the user ID for SLURM jobs
+# RFC: https://github.com/interlink-hq/interlink-slurm-plugin/discussions/58
+# DefaultUID: 1000                # Optional: Set a default UID for all jobs
+#                                 # Can be overridden per-pod using spec.securityContext.runAsUser
 
 # Flavor configuration - predefined sets of SLURM submission options
 DefaultFlavor: "default"

--- a/examples/config/SlurmConfig.yaml
+++ b/examples/config/SlurmConfig.yaml
@@ -18,9 +18,10 @@ VerboseLogging: true
 ErrorsOnlyLogging: false
 EnableProbes: true
 
-# GID (Group ID) configuration - set the group ID for SLURM jobs
-# DefaultGID: 1000                # Optional: Set a default GID for all jobs
-# AllowGIDOverride: true          # Optional: Allow pods to override GID via annotation
+# UID (User ID) configuration - set the user ID for SLURM jobs
+# RFC: https://github.com/interlink-hq/interlink-slurm-plugin/discussions/58
+# DefaultUID: 1000                # Optional: Set a default UID for all jobs
+#                                 # Can be overridden per-pod using spec.securityContext.runAsUser
 
 # Flavor configuration - predefined sets of SLURM submission options
 DefaultFlavor: "default"
@@ -39,7 +40,7 @@ Flavors:
     Description: "GPU job with NVIDIA GPU (8 cores, 64GB RAM, 1 GPU)"
     CPUDefault: 8
     MemoryDefault: "64G"
-    # GID: 2000                   # Optional: Set a specific GID for this flavor
+    # UID: 2000                   # Optional: Set a specific UID for this flavor
     SlurmFlags:
       - "--gres=gpu:1"
       - "--partition=gpu"

--- a/examples/test-pod-uid.yaml
+++ b/examples/test-pod-uid.yaml
@@ -1,23 +1,25 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  name: test-pod-gid
+  name: test-pod-uid
   namespace: vk
   annotations:
-    # Example: Set a custom GID for this job
-    slurm-job.vk.io/gid: "1001"
     # Optional: Specify a flavor
     slurm-job.vk.io/flavor: "default"
     # Optional: Additional SLURM flags
     slurm-job.vk.io/flags: "--time=01:00:00"
 spec:
   restartPolicy: Never
+  # RFC: Use Kubernetes standard securityContext to set UID
+  # https://github.com/interlink-hq/interlink-slurm-plugin/discussions/58
+  securityContext:
+    runAsUser: 1001  # SLURM job will run as this user
   containers:
   - image: docker://ghcr.io/grycap/cowsay
     command: ["/bin/sh"]
-    args: ["-c", "echo 'Running with custom GID!' | /usr/games/cowsay && id"]
+    args: ["-c", "echo 'Running with custom UID!' | /usr/games/cowsay && id"]
     imagePullPolicy: Always
-    name: cowsay-gid
+    name: cowsay-uid
     resources:
       limits:
         cpu: 2

--- a/pkg/slurm/func.go
+++ b/pkg/slurm/func.go
@@ -159,22 +159,14 @@ func NewSlurmConfig() (SlurmConfig, error) {
 			log.G(context.Background()).Info("No flavors configured, using default behavior")
 		}
 
-		// Validate and log GID configuration
-		if SlurmConfigInst.DefaultGID != nil {
-			if *SlurmConfigInst.DefaultGID < 0 {
-				err := fmt.Errorf("DefaultGID cannot be negative (got %d)", *SlurmConfigInst.DefaultGID)
+		// Validate and log UID configuration (RFC: https://github.com/interlink-hq/interlink-slurm-plugin/discussions/58)
+		if SlurmConfigInst.DefaultUID != nil {
+			if *SlurmConfigInst.DefaultUID < 0 {
+				err := fmt.Errorf("DefaultUID cannot be negative (got %d)", *SlurmConfigInst.DefaultUID)
 				log.G(context.Background()).Error(err)
 				return SlurmConfig{}, err
 			}
-			log.G(context.Background()).Infof("Default GID set to: %d", *SlurmConfigInst.DefaultGID)
-
-			if SlurmConfigInst.AllowGIDOverride {
-				log.G(context.Background()).Info("GID override via pod annotations is enabled")
-			} else {
-				log.G(context.Background()).Info("GID override via pod annotations is disabled")
-			}
-		} else if SlurmConfigInst.AllowGIDOverride {
-			log.G(context.Background()).Info("GID override via pod annotations is enabled (no default GID set)")
+			log.G(context.Background()).Infof("Default UID set to: %d (jobs will run as this user unless overridden by pod securityContext)", *SlurmConfigInst.DefaultUID)
 		}
 	}
 	return SlurmConfigInst, nil

--- a/pkg/slurm/types.go
+++ b/pkg/slurm/types.go
@@ -11,7 +11,7 @@ type FlavorConfig struct {
 	Description   string   `yaml:"Description"`
 	CPUDefault    int64    `yaml:"CPUDefault"`
 	MemoryDefault string   `yaml:"MemoryDefault"` // e.g., "16G", "32000M", "1024"
-	GID           *int64   `yaml:"GID"`           // Optional Group ID for this flavor
+	UID           *int64   `yaml:"UID"`           // Optional User ID for this flavor
 	SlurmFlags    []string `yaml:"SlurmFlags"`
 }
 
@@ -44,9 +44,9 @@ func (f *FlavorConfig) Validate() error {
 		}
 	}
 
-	// Validate GID if set
-	if f.GID != nil && *f.GID < 0 {
-		return fmt.Errorf("flavor '%s': GID cannot be negative (got %d)", f.Name, *f.GID)
+	// Validate UID if set
+	if f.UID != nil && *f.UID < 0 {
+		return fmt.Errorf("flavor '%s': UID cannot be negative (got %d)", f.Name, *f.UID)
 	}
 
 	return nil
@@ -83,8 +83,7 @@ type SlurmConfig struct {
 	ContainerRuntime          string                  `yaml:"ContainerRuntime" default:"singularity"` // "singularity" or "enroot"
 	Flavors                   map[string]FlavorConfig `yaml:"Flavors"`
 	DefaultFlavor             string                  `yaml:"DefaultFlavor"`
-	DefaultGID                *int64                  `yaml:"DefaultGID"`       // Optional default Group ID for all jobs
-	AllowGIDOverride          bool                    `yaml:"AllowGIDOverride"` // Allow pod annotations to override GID
+	DefaultUID                *int64                  `yaml:"DefaultUID"` // Optional default User ID for all jobs (RFC: https://github.com/interlink-hq/interlink-slurm-plugin/discussions/58)
 }
 
 type CreateStruct struct {


### PR DESCRIPTION
This commit implements comprehensive GID (Group ID) support for SLURM jobs, allowing fine-grained control over file access permissions, license group management, and shared storage access.

Key features:
- Global DefaultGID configuration for all jobs
- Per-flavor GID settings
- Pod-level GID override via slurm-job.vk.io/gid annotation
- Priority-based GID resolution (annotation > flavor > default)
- Comprehensive validation and error handling
- Full backwards compatibility (all GID settings are optional)

Changes:
- Added DefaultGID and AllowGIDOverride to SlurmConfig
- Added GID field to FlavorConfig
- Implemented GID resolution logic in prepare.go
- Added validation for GID values (must be non-negative)
- Added comprehensive unit tests for GID functionality
- Updated configuration examples with GID settings
- Added test-pod-gid.yaml example
- Updated README with detailed GID documentation

The --gid flag is automatically added to SBATCH scripts when configured.

<!--
A good PR should describe what benefit this brings to the repository.
Ideally, there is an existing issue which the PR address.

Please check the Contributing guide CONTRIBUTING.md for style requirements and
advice.
-->

# Summary

<!-- Describe in plain English what this PR does -->

---

<!-- Add, if any, the related issue here, e.g. #6 -->

**Related issue :**
