### PR TITLE
fix: add UID field to FlavorResolution struct

### DIFF
--- a/pkg/slurm/prepare.go
+++ b/pkg/slurm/prepare.go
@@ -57,7 +57,8 @@ type ResourceLimits struct {
 type FlavorResolution struct {
 	FlavorName    string
 	CPUDefault    int64
-	MemoryDefault int64 // in bytes
+	MemoryDefault int64  // in bytes
+	UID           *int64 // Optional User ID for this flavor
 	SlurmFlags    []string
 }
 
@@ -391,6 +392,7 @@ func resolveFlavor(Ctx context.Context, config SlurmConfig, metadata metav1.Obje
 		FlavorName:    flavorName,
 		CPUDefault:    selectedFlavor.CPUDefault,
 		MemoryDefault: memoryBytes,
+		UID:           selectedFlavor.UID,
 		SlurmFlags:    selectedFlavor.SlurmFlags,
 	}, nil
 }


### PR DESCRIPTION
The FlavorResolution struct was missing the UID field which caused compilation errors when resolving flavors. This field is needed to pass the UID from FlavorConfig through to the job submission logic.

Fixes:
- Added UID *int64 field to FlavorResolution struct
- Updated FlavorResolution construction to include UID from FlavorConfig

<!--
A good PR should describe what benefit this brings to the repository.
Ideally, there is an existing issue which the PR address.

Please check the Contributing guide CONTRIBUTING.md for style requirements and
advice.
-->

# Summary

<!-- Describe in plain English what this PR does -->

---

<!-- Add, if any, the related issue here, e.g. #6 -->

**Related issue :**
