### PR TITLE
add URI regex and tests

### DIFF
--- a/pkg/slurm/prepare.go
+++ b/pkg/slurm/prepare.go
@@ -1849,12 +1849,17 @@ func prepareImage(Ctx context.Context, config SlurmConfig, metadata metav1.Objec
 
 	// If imagePrefix begins with "/", then it must be an absolute path instead of for example docker://some/image.
 	// The file should be one of https://docs.sylabs.io/guides/3.1/user-guide/cli/singularity_run.html#synopsis format.
+	// Check if the image already has a URI scheme (e.g., docker://, oras://, library://, shub://)
+	// to avoid double-prefixing (e.g., docker://oras://...).
+	hasScheme := regexp.MustCompile(`^[a-zA-Z][a-zA-Z0-9+\-.]*://`).MatchString(image)
 	if strings.HasPrefix(image, "/") {
 		log.G(Ctx).Warningf("image set to %s is an absolute path. Prefix won't be added.", image)
-	} else if !strings.HasPrefix(image, imagePrefix) {
+	} else if hasScheme {
+		log.G(Ctx).Infof("image %s already has a URI scheme. Prefix won't be added.", image)
+	} else if imagePrefix != "" {
 		image = imagePrefix + containerImage
 	} else {
-		log.G(Ctx).Warningf("imagePrefix set to %s but already present in the image name %s. Prefix won't be added.", imagePrefix, image)
+		log.G(Ctx).Warningf("imagePrefix is empty and image %s has no URI scheme. Image will be used as-is.", image)
 	}
 	return image
 }

--- a/pkg/slurm/prepare_test.go
+++ b/pkg/slurm/prepare_test.go
@@ -146,6 +146,51 @@ func TestPrepareImage(t *testing.T) {
 			containerImage:   "docker://nginx:alpine",
 			expectedContains: "docker://nginx:alpine",
 		},
+		{
+			name: "oras image not double-prefixed with docker",
+			config: SlurmConfig{
+				ImagePrefix: "docker://",
+			},
+			metadata:         metav1.ObjectMeta{},
+			containerImage:   "oras://myregistry.example.com/myimage:v1",
+			expectedContains: "oras://myregistry.example.com/myimage:v1",
+		},
+		{
+			name: "library image not double-prefixed",
+			config: SlurmConfig{
+				ImagePrefix: "docker://",
+			},
+			metadata:         metav1.ObjectMeta{},
+			containerImage:   "library://user/collection/image:tag",
+			expectedContains: "library://user/collection/image:tag",
+		},
+		{
+			name: "shub image not double-prefixed",
+			config: SlurmConfig{
+				ImagePrefix: "docker://",
+			},
+			metadata:         metav1.ObjectMeta{},
+			containerImage:   "shub://vsoch/hello-world",
+			expectedContains: "shub://vsoch/hello-world",
+		},
+		{
+			name: "empty prefix with plain image",
+			config: SlurmConfig{
+				ImagePrefix: "",
+			},
+			metadata:         metav1.ObjectMeta{},
+			containerImage:   "busybox:1.35",
+			expectedContains: "busybox:1.35",
+		},
+		{
+			name: "empty prefix with oras image",
+			config: SlurmConfig{
+				ImagePrefix: "",
+			},
+			metadata:         metav1.ObjectMeta{},
+			containerImage:   "oras://myregistry.example.com/myimage:latest",
+			expectedContains: "oras://myregistry.example.com/myimage:latest",
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary

- **Fix double-prefixing of images with existing URI schemes**: When `ImagePrefix` is set to
  `docker://`, images that already have a URI scheme (e.g., `oras://`, `library://`, `shub://`)
  were incorrectly prefixed, producing invalid URIs like `docker://oras://...`. The fix adds
  a regex check for any existing URI scheme (`^[a-zA-Z][a-zA-Z0-9+\-.]*://`) and skips
  prefixing when one is detected. All valid Singularity/Apptainer transport protocols are
  URI-scheme based (ref: [Apptainer pull docs](https://apptainer.org/docs/user/latest/cli/apptainer_pull.html)).

  Seen in practice when using JupyterHub with interLink: JHub profiles allow users to select
  from different images (Docker and SIF), but the `ImagePrefix` config and the
  `slurm-job.vk.io/image-root` annotation are too coarse-grained to handle mixed image types
  in the same profile.

  Error before fix:
  ```
  FATAL:   Unable to handle docker://oras://myregistry.example.com/myimage:latest uri:
  unable to parse image name docker://oras://myregistry.example.com/myimage:latest: invalid reference format
  ```

- **Unit tests**: Added test cases for `oras://`, `library://`, `shub://` images with
  `ImagePrefix: "docker://"`, and for empty prefix scenarios.

## Test plan

- [x] Run unit tests: `go test ./pkg/slurm/ -run TestPrepareImage -v`
- [x] Verify `docker://` prefix is still added to plain images (e.g., `busybox:1.35`)
- [x] Verify `oras://` images are not double-prefixed
- [x] Verify absolute path images (e.g., `/path/to/image.sif`) are unchanged
- [x] Verify `library://` and `shub://` images are not double-prefixed

## Notes

Should this be documented anywhere?

Closes #130