### PR TITLE
Refactor Dockerfile: ARM build fails + slow Slurm source compilation 

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,3 +1,6 @@
+# Change tag to switch Slurm version
+ARG SLURM_TAG=25.11-ubuntu24.04
+
 FROM golang:1.24 AS build-stage
 
 WORKDIR /app
@@ -5,58 +8,37 @@ WORKDIR /app
 COPY . .
 RUN CGO_ENABLED=0 GOOS=linux go build -o bin/slurm-sidecar cmd/main.go
 
-# Deploy the application binary into a lean image
-#FROM ubuntu:latest AS build-release-stage
-FROM almalinux:9
+# Copy sackd from the Slinky sackd image (not included in slurmd)
+FROM ghcr.io/slinkyproject/sackd:${SLURM_TAG} AS sackd-source
 
-# Settings for all images
-ENV TIMEZONE=America/New_York
+# Base on official Slinky slurmd image
+FROM ghcr.io/slinkyproject/slurmd:${SLURM_TAG}
 
-# Install system packages (without Slurm -- built from source below)
-RUN DEBIAN_FRONTEND=noninteractive \
-  dnf install -y epel-release \
-  && /usr/bin/crb enable \
-  && dnf install -y --allowerasing rpm-build apptainer sshpass slirp4netns iproute curl tar xz make gcc ca-certificates \
-  wget bzip2 python3 munge-devel pam-devel readline-devel perl-ExtUtils-MakeMaker \
-  autoconf automake mariadb-devel libjwt-devel json-c-devel http-parser-devel \
-  && update-ca-trust \
-  && dnf clean all
+ENV DEBIAN_FRONTEND=noninteractive
 
-# Build and install Slurm 25.11 from source (AlmaLinux 9 ships 22.05 which is
-# incompatible with Slinky's slurmctld 25.11 wire protocol)
-RUN wget https://download.schedmd.com/slurm/slurm-25.11.4.tar.bz2 \
-  && rpmbuild -ta --with jwt --with slurmrestd slurm-25.11.4.tar.bz2 \
-  && dnf install -y ~/rpmbuild/RPMS/x86_64/slurm-25.11.4*.rpm \
-  ~/rpmbuild/RPMS/x86_64/slurm-slurmd-25.11.4*.rpm \
-  ~/rpmbuild/RPMS/x86_64/slurm-slurmctld-25.11.4*.rpm \
-  ~/rpmbuild/RPMS/x86_64/slurm-sackd-25.11.4*.rpm \
-  && rm -rf ~/rpmbuild slurm-25.11.4.tar.bz2
+# Install runtime dependencies + Apptainer
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends \
+    software-properties-common sshpass slirp4netns iproute2 curl ca-certificates \
+  && add-apt-repository -y ppa:apptainer/ppa \
+  && apt-get update \
+  && apt-get install -y --no-install-recommends apptainer \
+  && update-ca-certificates \
+  && rm -rf /var/lib/apt/lists/*
 
-# Ensure slurm user exists (slurm-setuser is not available in 25.11 RPMs)
-RUN id slurm &>/dev/null || useradd -r -s /sbin/nologin slurm
+# Copy sackd binary (auth daemon for auth/slurm)
+COPY --from=sackd-source /usr/sbin/sackd /usr/sbin/sackd
+
+# Slurm directories
+RUN mkdir -p /var/spool/slurmctld /var/spool/slurmd /var/log/slurm /etc/slurm
 
 # Slurm configuration
 COPY docker/slurm.conf /etc/slurm/slurm.conf
 COPY docker/cgroup.conf /etc/slurm/cgroup.conf
-RUN mkdir -p /var/spool/slurmctld
-RUN mkdir -p /var/spool/slurmd /var/log/slurm /etc/slurm
 
 # Startup configuration
 COPY docker/startup.sh /etc/startup.sh
 RUN chmod 555 /etc/startup.sh
-
-# Install MUNGE from source (to get the latest version)
-RUN dnf install -y wget tar make gcc openssl-devel libtool autoconf automake \
-  && dnf clean all
-
-RUN wget https://github.com/dun/munge/releases/download/munge-0.5.16/munge-0.5.16.tar.xz \
-  && tar -xf munge-0.5.16.tar.xz \
-  && cd munge-0.5.16 \
-  && ./configure --prefix=/ --sysconfdir=/etc/munge --with-munge-user=root --with-munge-group=root \
-  && make \
-  && make install
-RUN ln -s /usr/local/munge/bin/* /usr/local/bin/ && ln -s /usr/local/munge/sbin/* /usr/local/sbin/
-
 
 WORKDIR /root
 


### PR DESCRIPTION
## Summary

- Base the sidecar image on `ghcr.io/slinkyproject/slurmd` instead of AlmaLinux 9 + rpmbuild from source
- Remove Slurm source compilation (~1h18m) and Munge source build
- Add `SLURM_TAG` build arg to control Slurm version
- Install Apptainer from official PPA (supports amd64 + arm64)

Closes #132 

## What changed

The Dockerfile was building Slurm 25.11 from source via `rpmbuild`, which:
- Hardcoded `x86_64` RPM paths, breaking ARM64 builds
- Took ~1h18m under QEMU emulation in CI

Now the image is based on the official Slinky `slurmd` image, which ships pre-built Slurm binaries for both architectures. Build time drops to ~8m (on my machine).

The Munge source build is also removed since the sidecar uses `auth/slurm` (sackd), not Munge.

## Test plan

```bash
# Set up multi-arch builder
docker buildx create --name multiarch --use
docker run --rm --privileged multiarch/qemu-user-static --reset -p yes

# Build for both architectures
docker buildx build --platform linux/amd64,linux/arm64 -f docker/Dockerfile .
```

- [x] Both amd64 and arm64 images build successfully
- [x] Sidecar connects to slurmctld and `sbatch`/`sinfo` work
