### PR TITLE
feat: report the allocated compute node in pod status

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,7 +1,7 @@
 # Change tag to switch Slurm version
 ARG SLURM_TAG=25.11-ubuntu24.04
 
-FROM golang:1.24 AS build-stage
+FROM golang:1.26 AS build-stage
 
 WORKDIR /app
 

--- a/pkg/slurm/Status.go
+++ b/pkg/slurm/Status.go
@@ -477,6 +477,15 @@ func (h *SidecarHandler) StatusHandler(w http.ResponseWriter, r *http.Request) {
 			}
 
 		}
+
+		// Report which compute node each job landed on. The generated batch script
+		// records it in the pod's own directory as soon as the job starts, so this
+		// stays empty for as long as the job is queued. interLink uses it to point
+		// per-pod shadow tunnels at the right host.
+		for i := range resp {
+			resp[i].NodeName = readComputeNode(h.Config.DataRootFolder + resp[i].PodNamespace + "-" + resp[i].PodUID)
+		}
+
 		cachedStatus = resp
 		timer = time.Now()
 	} else {

--- a/pkg/slurm/func.go
+++ b/pkg/slurm/func.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"path/filepath"
+	"strings"
 
 	"go.opentelemetry.io/otel/trace"
 	"k8s.io/client-go/kubernetes"
@@ -16,6 +18,21 @@ import (
 
 var SlurmConfigInst SlurmConfig
 var Clientset *kubernetes.Clientset
+
+// ComputeNodeFileName is the file, inside a pod's own directory, where the generated
+// batch script records the compute node the job is running on.
+const ComputeNodeFileName = "compute-node"
+
+// readComputeNode returns the compute node recorded for the job in podDir, or an
+// empty string if the job has not started yet. A missing file is the normal state
+// for a queued job, not an error.
+func readComputeNode(podDir string) string {
+	raw, err := os.ReadFile(filepath.Join(podDir, ComputeNodeFileName))
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(raw))
+}
 
 // TODO: implement factory design
 

--- a/pkg/slurm/prepare.go
+++ b/pkg/slurm/prepare.go
@@ -1192,6 +1192,11 @@ func produceSLURMScript(
 		prefix += "\n" + config.Commandprefix
 	}
 
+	// Record the compute node the job landed on, for StatusHandler to report back to
+	// interLink. The generator knows the pod's directory, so nothing has to derive it
+	// at runtime. Best-effort: a failed write must never take the workload down.
+	prefix += "\nhostname -f > " + filepath.Join(path, ComputeNodeFileName) + " || true"
+
 	if wstunnelClientCommands, ok := metadata.Annotations["interlink.eu/wstunnel-client-commands"]; ok {
 		prefix += "\n" + wstunnelClientCommands + "\n"
 	}

--- a/pkg/slurm/prepare_test.go
+++ b/pkg/slurm/prepare_test.go
@@ -602,3 +602,60 @@ t.Errorf("normalizeVolumeFileContent(%q) = %q, want %q", tc.input, got, tc.want)
 })
 }
 }
+
+// The batch script records the compute node itself. The generator knows the pod's
+// directory, so nothing downstream has to reverse-engineer it from scontrol output
+// or guess by picking the most recently written file in a shared jobs directory.
+func TestProduceSLURMScriptRecordsComputeNode(t *testing.T) {
+	ctx := context.Background()
+	workingDir := t.TempDir()
+
+	pod := v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "cn-pod",
+			Namespace: "default",
+			UID:       "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+		},
+	}
+
+	if _, err := produceSLURMScript(ctx, SlurmConfig{BashPath: "/bin/bash"}, pod, workingDir, pod.ObjectMeta, nil, ResourceLimits{CPU: 1, Memory: 1024 * 1024}, false, false, nil); err != nil {
+		t.Fatalf("produceSLURMScript() unexpected error: %v", err)
+	}
+
+	raw, err := os.ReadFile(filepath.Join(workingDir, "job.slurm"))
+	if err != nil {
+		t.Fatalf("read job.slurm: %v", err)
+	}
+	content := string(raw)
+
+	want := "hostname -f > " + filepath.Join(workingDir, ComputeNodeFileName)
+	if !strings.Contains(content, want) {
+		t.Errorf("job.slurm must record the compute node (%q)\n---\n%s", want, content)
+	}
+
+	// It has to run before the workload, so a tunnel can be pointed at the node
+	// while the workload is still coming up.
+	cn := strings.Index(content, want)
+	job := strings.Index(content, filepath.Join(workingDir, "job.sh"))
+	if cn < 0 || job < 0 || cn > job {
+		t.Errorf("the compute-node write must precede job.sh (cn@%d job.sh@%d)\n---\n%s", cn, job, content)
+	}
+}
+
+func TestReadComputeNode(t *testing.T) {
+	t.Run("returns the recorded node", func(t *testing.T) {
+		dir := t.TempDir()
+		if err := os.WriteFile(filepath.Join(dir, ComputeNodeFileName), []byte("node042.hpc.example.org\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if got := readComputeNode(dir); got != "node042.hpc.example.org" {
+			t.Errorf("readComputeNode() = %q, want %q", got, "node042.hpc.example.org")
+		}
+	})
+
+	t.Run("a queued job has no file yet, which is not an error", func(t *testing.T) {
+		if got := readComputeNode(t.TempDir()); got != "" {
+			t.Errorf("readComputeNode() = %q, want empty", got)
+		}
+	})
+}


### PR DESCRIPTION
Plugin side of interlink-hq/interLink#550. Part of interlink-hq/interLink#545.

> **Depends on interlink-hq/interLink#550 being merged and released.** This branch uses `PodStatus.NodeName`, which that PR adds, so it does not compile against the currently pinned `github.com/interlink-hq/interlink`. Once there is a tag: `go get github.com/interlink-hq/interlink@<tag> && go mod tidy`. Everything else here is verified — built and tested green against a local `replace` pointing at that branch.

## Problem

Reaching a service inside an offloaded pod — a notebook, a Ray dashboard — means knowing which node the job actually landed on. Nothing in the pod spec can carry it: the pod is created long before SLURM schedules anything, and the plugin never told anyone afterwards.

Deployments that needed this worked around it with a `CommandPrefix` that reverse-engineered the pod directory from `scontrol show job $SLURM_JOB_ID | grep StdOut | xargs dirname`, then had the consumer read back the newest `compute-node` file in the shared jobs directory. That guess races the moment two users start a job at the same time.

## What this does

The generated batch script records the node itself, and `StatusHandler` reports it upstream.

`produceSLURMScript` emits, before the workload:

```bash
hostname -f > <pod dir>/compute-node || true
```

The script generator already knows the per-pod directory, so nothing downstream has to derive it. `hostname -f` runs on the node itself, so the name is the one a login node can actually resolve — not guaranteed of the name SLURM knows it by. Best-effort (`|| true`): a failed write must never take the workload down.

`StatusHandler` reads that file for every pod it reports on and sets:

```go
commonIL.PodStatus{..., NodeName: readComputeNode(podDir)}
```

interLink uses it to point per-pod shadow tunnels at the right host (interlink-hq/interLink#550).

Second commit: build: move the builder image to golang 1.26. interLink's go.mod requires go 1.26.0, and the official golang images set GOTOOLCHAIN=local, so a 1.24 builder does not fetch a newer toolchain — it fails with go: go.mod requires go >= 1.26.0 (running go 1.24.13; GOTOOLCHAIN=local). Bumped here so the image still builds once go.mod points at the release. The current go.mod, which still asks for 1.24.0, builds unchanged on the newer toolchain.

## Compatibility

A missing file is the normal state of a queued job, not an error — `readComputeNode` returns `""`. `NodeName` is `omitempty`, so nothing changes on the wire until a job is actually running, and consumers that don't read it are unaffected.

The `hostname -f` line is unconditional. It costs one extra line in every generated `job.slurm` and one `os.ReadFile` per pod per status poll on a directory the plugin already owns.

## Testing

`go build ./... && go test ./pkg/...` clean (against interLink#550's branch).

- `TestProduceSLURMScriptRecordsComputeNode` — asserts the write is emitted with the right path, and that it precedes `job.sh` so a tunnel can be pointed at the node while the workload is still coming up
- `TestReadComputeNode` — reads back a recorded node; returns empty for a queued job without treating it as an error

## Note on the mesh fix

This touches `produceSLURMScript`, the same function as the mesh `$@` fix PR. I merged the two locally to check: **`prepare.go` merges cleanly** — the `hostname -f` write lands in the prefix before the mesh block, so the `mesh.sh <job.sh>` line is untouched. The only conflict is `prepare_test.go`, where both branches append tests to the end of the file; resolution is "keep both blocks". All tests pass on the merged result. Merge order between the two doesn't matter.
