### PR TITLE
fix: run the workload inside the mesh network namespace

### DIFF
--- a/pkg/slurm/prepare.go
+++ b/pkg/slurm/prepare.go
@@ -1196,6 +1196,11 @@ func produceSLURMScript(
 		prefix += "\n" + wstunnelClientCommands + "\n"
 	}
 
+	// mesh.sh sets up the mesh network in an unshared netns and then execs its "$@".
+	// The workload has to be that argument, so it must end up on the SAME line as
+	// mesh.sh; the default newline separator below would run it after mesh.sh had
+	// already exited, outside the netns.
+	meshDetected := false
 	if preExecAnnotations, ok := metadata.Annotations["slurm-job.vk.io/pre-exec"]; ok {
 		// Check if pre-exec contains a heredoc that creates mesh.sh
 		if strings.Contains(preExecAnnotations, "cat <<'EOFMESH' > $TMPDIR/mesh.sh") {
@@ -1211,6 +1216,7 @@ func produceSLURMScript(
 					// wrote mesh.sh, now add pre-exec without the mesh.sh heredoc
 					preExecWithoutHeredoc := removeHeredoc(preExecAnnotations, "EOFMESH")
 					prefix += "\n" + preExecWithoutHeredoc + "\n" + fmt.Sprintf(" %s", meshPath)
+					meshDetected = true
 				}
 
 				err = os.Chmod(path+"/mesh.sh", 0774)
@@ -1231,18 +1237,25 @@ func produceSLURMScript(
 		}
 	}
 
+	// NOTE: prefix is separated from f.Name() by a newline, not a space.  When
+	// SHARED_FS=false the prefix ends with a base64 heredoc end-marker (e.g.
+	// "VKDATA_abc").  If f.Name() were appended on the same line ("VKDATA_abc
+	// /path/to/job.sh") bash would not recognise it as the end-of-heredoc, consume
+	// the rest of the script into the heredoc, and never execute job.sh.
+	//
+	// A mesh prefix is the exception: there job.sh must be mesh.sh's argument. The
+	// mesh prefix never ends in a heredoc marker, so the two cases cannot collide.
+	separator := "\n"
+	if meshDetected {
+		separator = " "
+	}
+
 	sbatch_macros := "#!" + config.BashPath +
 		"\n#SBATCH --job-name=" + podUID +
 		"\n#SBATCH --output=" + path + "/job.out" +
 		sbatchFlagsAsString +
 		"\n" +
-		// NOTE: prefix must be separated from f.Name() by a newline, not a
-		// space.  When SHARED_FS=false the prefix ends with a base64 heredoc
-		// end-marker (e.g. "VKDATA_abc").  If f.Name() were appended on the
-		// same line ("VKDATA_abc /path/to/job.sh") bash would not recognise
-		// it as the end-of-heredoc, consume the rest of the script into the
-		// heredoc, and never execute job.sh.
-		prefix + "\n" + f.Name() +
+		prefix + separator + f.Name() +
 		"\n"
 
 	log.G(Ctx).Debug("--- Writing SLURM sbatch file")

--- a/pkg/slurm/prepare_test.go
+++ b/pkg/slurm/prepare_test.go
@@ -602,3 +602,67 @@ t.Errorf("normalizeVolumeFileContent(%q) = %q, want %q", tc.input, got, tc.want)
 })
 }
 }
+
+// mesh.sh unshares a network namespace, sets the mesh up inside it and then execs
+// its "$@". If job.sh is emitted on the following line instead of as that argument,
+// mesh.sh exits first and the workload runs outside the namespace: the job succeeds
+// but has no mesh connectivity, which is silent and hard to diagnose.
+func TestProduceSLURMScriptRunsWorkloadInsideMeshNetns(t *testing.T) {
+	ctx := context.Background()
+	workingDir := t.TempDir()
+
+	pod := v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "mesh-pod",
+			Namespace: "default",
+			UID:       "11111111-2222-3333-4444-555555555555",
+			Annotations: map[string]string{
+				"slurm-job.vk.io/pre-exec": "cat <<'EOFMESH' > $TMPDIR/mesh.sh\n#!/bin/bash\nexec \"$@\"\nEOFMESH\n",
+			},
+		},
+	}
+
+	if _, err := produceSLURMScript(ctx, SlurmConfig{BashPath: "/bin/bash"}, pod, workingDir, pod.ObjectMeta, nil, ResourceLimits{CPU: 1, Memory: 1024 * 1024}, false, false, nil); err != nil {
+		t.Fatalf("produceSLURMScript() unexpected error: %v", err)
+	}
+
+	raw, err := os.ReadFile(filepath.Join(workingDir, "job.slurm"))
+	if err != nil {
+		t.Fatalf("read job.slurm: %v", err)
+	}
+
+	want := filepath.Join(workingDir, "mesh.sh") + " " + filepath.Join(workingDir, "job.sh")
+	if !strings.Contains(string(raw), want) {
+		t.Errorf("job.sh must be passed to mesh.sh as its argument (%q)\n---\n%s", want, string(raw))
+	}
+}
+
+// Without mesh.sh the separator must stay a newline: with SHARED_FS=false the
+// prefix ends in a base64 heredoc end-marker, and gluing job.sh onto that line
+// makes bash swallow the rest of the script instead of ending the heredoc.
+func TestProduceSLURMScriptKeepsNewlineBeforeJobScriptWithoutMesh(t *testing.T) {
+	ctx := context.Background()
+	workingDir := t.TempDir()
+
+	pod := v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "plain-pod",
+			Namespace: "default",
+			UID:       "66666666-7777-8888-9999-000000000000",
+		},
+	}
+
+	if _, err := produceSLURMScript(ctx, SlurmConfig{BashPath: "/bin/bash"}, pod, workingDir, pod.ObjectMeta, nil, ResourceLimits{CPU: 1, Memory: 1024 * 1024}, false, false, nil); err != nil {
+		t.Fatalf("produceSLURMScript() unexpected error: %v", err)
+	}
+
+	raw, err := os.ReadFile(filepath.Join(workingDir, "job.slurm"))
+	if err != nil {
+		t.Fatalf("read job.slurm: %v", err)
+	}
+
+	jobScript := filepath.Join(workingDir, "job.sh")
+	if !strings.Contains(string(raw), "\n"+jobScript) {
+		t.Errorf("job.sh must start its own line when no mesh script is in play\n---\n%s", string(raw))
+	}
+}


### PR DESCRIPTION
Fixes https://github.com/interlink-hq/interlink-slurm-plugin/issues/149

### Problem

With full mesh enabled, the generated `job.slurm` emits `mesh.sh` and the workload on separate lines, so `mesh.sh` gets no `"$@"`, exits, and the workload runs outside the mesh network namespace. The job succeeds either way, so the failure is silent — it looks like a WireGuard misconfiguration rather than a script generation bug.

### Fix

Emit the workload as `mesh.sh`'s argument, but only when a mesh script was actually extracted:

```go
separator := "\n"
if meshDetected {
	separator = " "
}
```

**Before**

```bash
 /.../mesh.sh
/.../job.sh
```

**After**

```bash
 /.../mesh.sh /.../job.sh
```

The guard is load-bearing, not defensive. The newline has to stay for every other job: with `SHARED_FS=false` the prefix ends in a base64 heredoc end-marker, and gluing `job.sh` onto that line would make bash consume the rest of the script into the heredoc instead of terminating it. The existing comment explaining that is kept and extended to say why mesh is the exception — a mesh prefix never ends in a heredoc marker, so the two cases cannot collide.

### Tests

- `TestProduceSLURMScriptRunsWorkloadInsideMeshNetns` — asserts `mesh.sh <job.sh>` on one line. Verified it **fails** without the fix, so it actually pins the behaviour.
- `TestProduceSLURMScriptKeepsNewlineBeforeJobScriptWithoutMesh` — asserts `job.sh` still starts its own line for non-mesh jobs, guarding the `SHARED_FS=false` path.

`go build ./... && go test ./pkg/...` clean.

### Note on #148

This touches `produceSLURMScript`, the same function as #148. I merged the two locally to check: **`prepare.go` merges cleanly** — the edits are in different parts of the function, and the `hostname -f` write from #148 lands before the mesh block, leaving the `mesh.sh <job.sh>` line intact. The only conflict is `prepare_test.go`, where both branches append tests to the end of the file; resolution is "keep both blocks". All tests pass on the merged result. Merge order doesn't matter.

Not related to the SSH work in interlink-hq/interLink#550 — this is a pre-existing mesh bug found while working on that.
