### PR TITLE
fix: do not panic deleting a pod that never got a Slurm job

### DIFF
--- a/pkg/slurm/prepare.go
+++ b/pkg/slurm/prepare.go
@@ -1614,7 +1614,13 @@ func deleteContainer(Ctx context.Context, config SlurmConfig, podUID string, JID
 			log.G(Ctx).Info("- Deleted Job ", (*JIDs)[podUID].JID)
 		}
 	}
-	jid := (*JIDs)[podUID].JID
+	// Not every pod that reaches here has a job: sbatch may have been rejected, or
+	// the plugin may have restarted since submission. Both leave no JIDs entry, and
+	// dereferencing the nil *JidStruct panics the whole request handler.
+	jid := ""
+	if entry := (*JIDs)[podUID]; entry != nil {
+		jid = entry.JID
+	}
 	removeJID(podUID, JIDs)
 
 	errFirstAttempt := os.RemoveAll(path)

--- a/pkg/slurm/prepare_test.go
+++ b/pkg/slurm/prepare_test.go
@@ -602,3 +602,23 @@ t.Errorf("normalizeVolumeFileContent(%q) = %q, want %q", tc.input, got, tc.want)
 })
 }
 }
+
+// TestDeleteContainerWithoutJID covers deleting a pod that never got a Slurm job:
+// sbatch may have been rejected, or the plugin may have restarted since submission.
+// Both leave no JIDs entry, and reading the JID unguarded panicked the handler.
+func TestDeleteContainerWithoutJID(t *testing.T) {
+	dir := t.TempDir()
+	podDir := filepath.Join(dir, "ns-11111111-2222-3333-4444-555555555555")
+	if err := os.MkdirAll(podDir, 0o755); err != nil {
+		t.Fatalf("failed to create pod dir: %v", err)
+	}
+
+	JIDs := map[string]*JidStruct{}
+	err := deleteContainer(context.Background(), SlurmConfig{}, "11111111-2222-3333-4444-555555555555", &JIDs, podDir)
+	if err != nil {
+		t.Fatalf("deleteContainer returned an error for a pod with no job: %v", err)
+	}
+	if _, statErr := os.Stat(podDir); !os.IsNotExist(statErr) {
+		t.Errorf("expected the pod directory to be removed, stat returned %v", statErr)
+	}
+}


### PR DESCRIPTION
Closes #151 .

`deleteContainer` reads `(*JIDs)[podUID].JID` outside the `checkIfJidExists` guard, so a pod with no entry dereferences a nil `*JidStruct` and takes the HTTP handler down with it:

```
http: panic serving 127.0.0.1:49836: runtime error: invalid memory address or nil pointer dereference
  slurm.deleteContainer(...)                prepare.go:1622
  slurm.(*SidecarHandler).StopHandler(...)  Delete.go:53
```

Two ordinary situations get there: `sbatch` rejected the submission, so the pod never had a job; or the plugin restarted, since `JIDs` is in memory only. Either turns a routine delete into a 500 with no response body, and the caller retries against a handler that panics again.

## Change

Read the JID only when the entry exists:

```go
jid := ""
if entry := (*JIDs)[podUID]; entry != nil {
    jid = entry.JID
}
```

Everything after it — `os.RemoveAll` on the job directory, the span attributes — already handles a pod with no job, so nothing else changes.

## Testing

`TestDeleteContainerWithoutJID` deletes a pod with an empty `JIDs` map and asserts no error and that the directory is gone. It panics without the fix:

```
--- FAIL: TestDeleteContainerWithoutJID (0.00s)
panic: runtime error: invalid memory address or nil pointer dereference [recovered, repanicked]
```

Found while deploying the SSH shadow (interlink-hq/interLink#550) against three HPC sites; unrelated to that work.
