### PR TITLE
fix: make the sinfo resource probe work

### DIFF
--- a/pkg/slurm/Status.go
+++ b/pkg/slurm/Status.go
@@ -516,6 +516,13 @@ func (h *SidecarHandler) getSinfoSummary() (string, error) {
 	return execReturn.Stdout, nil
 }
 
+// sinfoTextSeparator separates the fields of sinfoTextFormat.  It must not be a
+// shell metacharacter: see getClusterResourcesFromText.
+const sinfoTextSeparator = ","
+
+// sinfoTextFormat asks sinfo for CPUs, real memory and free memory per node.
+const sinfoTextFormat = "--format=%c" + sinfoTextSeparator + "%m" + sinfoTextSeparator + "%e"
+
 // getClusterResources queries SLURM for the current resource usage of the cluster and
 // returns a PingResponse aligned with interlink-hq/interLink#516.
 //
@@ -626,10 +633,13 @@ func (h *SidecarHandler) getClusterResourcesFromJSON() (PingResponse, error) {
 // CPU counts, the CPU field reflects the total installed CPUs.
 func (h *SidecarHandler) getClusterResourcesFromText() (PingResponse, error) {
 	// %c = CPUs on node, %m = real memory (MB), %e = free memory (MB).
-	// Field separator is a pipe so that values with spaces still parse correctly.
+	// The separator has to survive a shell: Shell below means bash re-parses the
+	// whole command line, and any wrapper around SinfoPath that forwards to a login
+	// node hands it to a second shell there.  A comma is literal to both; a pipe
+	// turns the format into a three-stage pipeline.
 	shell := exec.ExecTask{
 		Command: h.Config.Sinfopath,
-		Args:    []string{"--noheader", "--format=%c|%m|%e"},
+		Args:    []string{"--noheader", sinfoTextFormat},
 		Shell:   true,
 	}
 	execReturn, err := shell.Execute()
@@ -695,7 +705,7 @@ func parseClusterResourcesFromText(stdout string) (PingResponse, error) {
 		if line == "" {
 			continue
 		}
-		parts := strings.Split(line, "|")
+		parts := strings.Split(line, sinfoTextSeparator)
 		if len(parts) < 3 {
 			continue
 		}

--- a/pkg/slurm/Status.go
+++ b/pkg/slurm/Status.go
@@ -520,8 +520,11 @@ func (h *SidecarHandler) getSinfoSummary() (string, error) {
 // shell metacharacter: see getClusterResourcesFromText.
 const sinfoTextSeparator = ","
 
-// sinfoTextFormat asks sinfo for CPUs, real memory and free memory per node.
-const sinfoTextFormat = "--format=%c" + sinfoTextSeparator + "%m" + sinfoTextSeparator + "%e"
+// sinfoTextFormat asks sinfo for the node name, CPUs, real memory and free memory.
+// The node name is what makes -N output usable: a node in two partitions is listed
+// once per partition, and counting it twice inflates the reported capacity.
+const sinfoTextFormat = "--format=%N" + sinfoTextSeparator + "%c" +
+	sinfoTextSeparator + "%m" + sinfoTextSeparator + "%e"
 
 // getClusterResources queries SLURM for the current resource usage of the cluster and
 // returns a PingResponse aligned with interlink-hq/interLink#516.
@@ -638,8 +641,10 @@ func (h *SidecarHandler) getClusterResourcesFromText() (PingResponse, error) {
 	// node hands it to a second shell there.  A comma is literal to both; a pipe
 	// turns the format into a three-stage pipeline.
 	shell := exec.ExecTask{
+		// -N is required: without it sinfo summarises per partition and prints
+		// ranges and "+" suffixes ("24+,191024+,184251-N/A") that are not numbers.
+		Args:    []string{"--noheader", "-N", sinfoTextFormat},
 		Command: h.Config.Sinfopath,
-		Args:    []string{"--noheader", sinfoTextFormat},
 		Shell:   true,
 	}
 	execReturn, err := shell.Execute()
@@ -700,27 +705,37 @@ func parseClusterResourcesFromJSON(stdout string) (PingResponse, error) {
 // per-node allocated CPU counts, so total CPU is the best approximation available.
 func parseClusterResourcesFromText(stdout string) (PingResponse, error) {
 	var totalCPU, totalMemMB, freeMemMB int64
+	// sinfo -N lists a node once per partition it belongs to.
+	counted := map[string]struct{}{}
 	for _, line := range strings.Split(stdout, "\n") {
 		line = strings.TrimSpace(line)
 		if line == "" {
 			continue
 		}
 		parts := strings.Split(line, sinfoTextSeparator)
-		if len(parts) < 3 {
+		if len(parts) < 4 {
 			continue
 		}
-		cpu, err := strconv.ParseInt(strings.TrimSpace(parts[0]), 10, 64)
+		node := strings.TrimSpace(parts[0])
+		if node == "" {
+			continue
+		}
+		cpu, err := strconv.ParseInt(strings.TrimSpace(parts[1]), 10, 64)
 		if err != nil {
 			continue
 		}
-		mem, err := strconv.ParseInt(strings.TrimSpace(parts[1]), 10, 64)
+		mem, err := strconv.ParseInt(strings.TrimSpace(parts[2]), 10, 64)
 		if err != nil {
 			continue
 		}
-		free, err := strconv.ParseInt(strings.TrimSpace(parts[2]), 10, 64)
+		free, err := strconv.ParseInt(strings.TrimSpace(parts[3]), 10, 64)
 		if err != nil {
 			continue
 		}
+		if _, seen := counted[node]; seen {
+			continue
+		}
+		counted[node] = struct{}{}
 		totalCPU += cpu
 		totalMemMB += mem
 		freeMemMB += free

--- a/pkg/slurm/resources_test.go
+++ b/pkg/slurm/resources_test.go
@@ -12,10 +12,10 @@ import (
 // correctly aggregates per-node CPU and memory fields from a multi-line sinfo output
 // and returns a PingResponse aligned with interlink-hq/interLink#516.
 func TestGetClusterResourcesFromText_HappyPath(t *testing.T) {
-// Simulate what sinfo --noheader --format=%c,%m,%e would return for two nodes:
+// Simulate what sinfo --noheader -N --format=%N,%c,%m,%e returns for two nodes:
 //   node01: 16 CPUs, 128 000 MB total, 64 000 MB free
 //   node02: 32 CPUs,  64 000 MB total, 32 000 MB free
-sinfoLines := "16,128000,64000\n32,64000,32000\n"
+sinfoLines := "n01,16,128000,64000\nn02,32,64000,32000\n"
 
 resp, err := parseClusterResourcesFromText(sinfoLines)
 if err != nil {
@@ -45,7 +45,7 @@ t.Errorf("Memory = %q, want %q", resp.Resources.Memory, "96000Mi")
 // partial data does not cause a hard failure.
 func TestGetClusterResourcesFromText_SkipsInvalidLines(t *testing.T) {
 // Mix valid and invalid lines
-sinfoLines := "8,32000,16000\nbadline\n4,N/A,8000\n4,16000,8000\n"
+sinfoLines := "n01,8,32000,16000\nbadline\nn02,4,N/A,8000\nn03,4,16000,8000\n"
 
 resp, err := parseClusterResourcesFromText(sinfoLines)
 if err != nil {
@@ -545,5 +545,45 @@ for _, char := range []string{"|", ";", "&", "<", ">", "(", ")", "$", "`", "*", 
 if strings.Contains(sinfoTextFormat, char) {
 t.Errorf("sinfo format %q contains the shell metacharacter %q", sinfoTextFormat, char)
 }
+}
+}
+
+// TestParseClusterResourcesCountsEachNodeOnce covers sinfo -N listing a node once
+// per partition it belongs to. Adding those lines up reports more capacity than the
+// cluster has.
+func TestParseClusterResourcesCountsEachNodeOnce(t *testing.T) {
+resp, err := parseClusterResourcesFromText(
+"n01,16,128000,64000\nn01,16,128000,64000\nn02,32,64000,32000\n")
+if err != nil {
+t.Fatalf("unexpected error: %v", err)
+}
+if resp.Resources.CPU != "48" {
+t.Errorf("expected 48 CPUs counting n01 once, got %s", resp.Resources.CPU)
+}
+if resp.Resources.Memory != "96000Mi" {
+t.Errorf("expected 96000Mi counting n01 once, got %s", resp.Resources.Memory)
+}
+}
+
+// TestParseClusterResourcesRejectsAggregatedOutput is the regression this fix is
+// for. Without -N, sinfo summarises per partition and prints ranges and "+"
+// suffixes; every line was skipped and the virtual node advertised zero capacity,
+// so the scheduler refused every pod with "Insufficient cpu" while the node still
+// showed Ready.
+func TestParseClusterResourcesRejectsAggregatedOutput(t *testing.T) {
+resp, err := parseClusterResourcesFromText("24+,191024+,184251-N/A\n")
+if err != nil {
+t.Fatalf("unexpected error: %v", err)
+}
+if resp.Resources.CPU != "0" {
+t.Errorf("aggregated output has no parseable per-node numbers, got CPU=%s", resp.Resources.CPU)
+}
+}
+
+// TestSinfoIsQueriedPerNode pins the -N flag, without which the format above
+// cannot produce numbers at all.
+func TestSinfoIsQueriedPerNode(t *testing.T) {
+if !strings.Contains(sinfoTextFormat, "%N") {
+t.Errorf("the format must ask for the node name so duplicates can be detected: %s", sinfoTextFormat)
 }
 }

--- a/pkg/slurm/resources_test.go
+++ b/pkg/slurm/resources_test.go
@@ -4,6 +4,7 @@ import (
 "context"
 "encoding/json"
 "os"
+"strings"
 "testing"
 )
 
@@ -11,10 +12,10 @@ import (
 // correctly aggregates per-node CPU and memory fields from a multi-line sinfo output
 // and returns a PingResponse aligned with interlink-hq/interLink#516.
 func TestGetClusterResourcesFromText_HappyPath(t *testing.T) {
-// Simulate what sinfo --noheader --format=%c|%m|%e would return for two nodes:
+// Simulate what sinfo --noheader --format=%c,%m,%e would return for two nodes:
 //   node01: 16 CPUs, 128 000 MB total, 64 000 MB free
 //   node02: 32 CPUs,  64 000 MB total, 32 000 MB free
-sinfoLines := "16|128000|64000\n32|64000|32000\n"
+sinfoLines := "16,128000,64000\n32,64000,32000\n"
 
 resp, err := parseClusterResourcesFromText(sinfoLines)
 if err != nil {
@@ -44,7 +45,7 @@ t.Errorf("Memory = %q, want %q", resp.Resources.Memory, "96000Mi")
 // partial data does not cause a hard failure.
 func TestGetClusterResourcesFromText_SkipsInvalidLines(t *testing.T) {
 // Mix valid and invalid lines
-sinfoLines := "8|32000|16000\nbadline\n4|N/A|8000\n4|16000|8000\n"
+sinfoLines := "8,32000,16000\nbadline\n4,N/A,8000\n4,16000,8000\n"
 
 resp, err := parseClusterResourcesFromText(sinfoLines)
 if err != nil {
@@ -531,5 +532,18 @@ t.Fatalf("unexpected error: %v", err)
 }
 if resp.Status != "ok" {
 t.Errorf("Status = %q, want \"ok\" (default)", resp.Status)
+}
+}
+
+// TestSinfoTextFormatSurvivesAShell guards the separator in the sinfo format
+// string.  getClusterResourcesFromText runs with Shell: true, so bash re-parses
+// the command line, and any SinfoPath wrapper that forwards to a login node hands
+// it to a second shell there.  A pipe made bash read the format as a pipeline and
+// print "%m: command not found" on stderr, which the plugin treats as a failure.
+func TestSinfoTextFormatSurvivesAShell(t *testing.T) {
+for _, char := range []string{"|", ";", "&", "<", ">", "(", ")", "$", "`", "*", "?", " "} {
+if strings.Contains(sinfoTextFormat, char) {
+t.Errorf("sinfo format %q contains the shell metacharacter %q", sinfoTextFormat, char)
+}
 }
 }


### PR DESCRIPTION
Closes #153.

Two bugs, both of which have to go for the text fallback to work at all. Merging only the first would turn a loud failure into a silent one, so they ship together.

## 1. The shell ate the format string

`getClusterResourcesFromText` ran `sinfo --noheader --format=%c|%m|%e` with `Shell: true`, so go-execute handed the whole line to bash, which read the pipes as a pipeline:

```
/bin/bash: line 1: %m: command not found
/bin/bash: line 1: %e: command not found
```

The plugin treats non-empty stderr as a failure, so the interLink ping failed and the virtual node stayed `NotReady`.

Quoting is not enough. The usual setup points `SinfoPath` at a wrapper that runs `ssh user@login /usr/bin/sinfo "$@"`, so a second shell re-parses the arguments on the login node. The separator has to be literal to every shell it passes through, so it is now a comma — `%c`, `%m` and `%e` are integers or `N/A`, so nothing in the output can contain one.

## 2. ...and the output was not per node

`getClusterResourcesFromText` also ran sinfo without `-N`, so sinfo summarised per partition:

```
24+,191024+,184251-N/A
```

None of those parse as integers, every line was skipped, and the totals stayed zero. The ping still reported `ok`, so the virtual node went Ready advertising 0 CPU and 0 memory and the scheduler refused every pod with `Insufficient cpu`.

## Change

Ask for one line per node. `-N` lists a node once per partition it belongs to, so the format also carries `%N` and the parser counts each node once; without that a node in two partitions doubles the reported capacity.

## Testing

Four tests:

- `TestSinfoTextFormatSurvivesAShell` — asserts the format carries no shell metacharacter at all, rather than pinning one particular separator
- `TestParseClusterResourcesCountsEachNodeOnce` — the same node twice contributes once
- `TestParseClusterResourcesRejectsAggregatedOutput` — pins that aggregated output yields no numbers, which is what made this silent
- `TestSinfoIsQueriedPerNode` — the format must ask for `%N`, or duplicates cannot be detected

Verified on three clusters. Before, all three virtual nodes reported `cpu=0`; after:

| site | capacity |
|---|---|
| SURF ETP | 560 cpu / 8424406Mi |
| CERN | 4 cpu / 2032Mi |

Found while deploying the SSH shadow (interlink-hq/interLink#550); SURF's tutti and slinky partitions share a node, which is what surfaced the double-counting.


## Side effect: this unblocks the repo's own e2e job

`e2e` currently dies in `Setup e2e environment` before any test runs — the interLink
ping fails with the same `%m: command not found`, so the virtual node never reaches
Ready and `kubectl wait` times out. With this branch the suite actually runs: **16
passed, 1 failed**.

The remaining failure is `085-secret-envfrom`, the only test using `envFrom.secretRef`
(the explicit-`env` and `secretKeyRef` tests both pass). The job completes with exit
code 0 and the variables are resolved correctly, but its stdout never reaches the
test within the 20s window. It is unrelated to this change and predates it — it was
simply unreachable while setup was broken.

