### PR TITLE
fix: pass the job id as its own squeue argument

### DIFF
--- a/pkg/slurm/Status.go
+++ b/pkg/slurm/Status.go
@@ -153,12 +153,9 @@ func (h *SidecarHandler) StatusHandler(w http.ResponseWriter, r *http.Request) {
 
 			if checkIfJidExists(spanCtx, (h.JIDs), uid) {
 				// Eg of output: "R 0"
-				// With test, exit_code is better than DerivedEC, because for canceled jobs, it gives 15 while DerivedEC gives 0.
-				// states=all or else some jobs are hidden, then it is impossible to get job exit code.
-				cmd := []string{"--noheader", "-a", "--states=all", "-O", "exit_code,StateCompact", "-j ", (*h.JIDs)[uid].JID}
 				shell := exec.ExecTask{
 					Command: h.Config.Squeuepath,
-					Args:    cmd,
+					Args:    squeueStatusArgs((*h.JIDs)[uid].JID),
 					// true to be able to add prefix to squeue, but this is ugly
 					Shell: true,
 				}
@@ -497,6 +494,22 @@ func (h *SidecarHandler) StatusHandler(w http.ResponseWriter, r *http.Request) {
 		}
 		w.Write(bodyBytes)
 	}
+}
+
+// squeueStatusArgs builds the per-job status query.
+//
+// Every argument has to stand on its own.  Shell: true joins them for bash, which
+// splits them again, so "-j " with a trailing space used to reach squeue as
+// "-j <jid>" by accident.  A SqueuePath wrapper that forwards its arguments
+// faithfully - which any correctly quoting ssh shim does - passes "-j " through
+// intact instead, squeue sees an empty job id, and the poll fails with
+// "Invalid job id".
+//
+// exit_code is preferred over DerivedEC: a cancelled job reports 15 there and 0 in
+// DerivedEC.  --states=all is needed or terminal jobs are hidden and the exit code
+// cannot be read back.
+func squeueStatusArgs(jid string) []string {
+	return []string{"--noheader", "-a", "--states=all", "-O", "exit_code,StateCompact", "-j", jid}
 }
 
 // getSinfoSummary executes 'sinfo -s' command and returns the output

--- a/pkg/slurm/resources_test.go
+++ b/pkg/slurm/resources_test.go
@@ -4,6 +4,7 @@ import (
 "context"
 "encoding/json"
 "os"
+"strings"
 "testing"
 )
 
@@ -531,5 +532,26 @@ t.Fatalf("unexpected error: %v", err)
 }
 if resp.Status != "ok" {
 t.Errorf("Status = %q, want \"ok\" (default)", resp.Status)
+}
+}
+
+// TestSqueueStatusArgsAreSelfContained guards against reintroducing an argument
+// that only works because a shell splits it again.  The query used to pass "-j "
+// with a trailing space and the job id separately, which reached squeue correctly
+// only when bash rejoined them; a SqueuePath wrapper that quotes its arguments
+// made squeue see an empty job id and answer "Invalid job id", leaving the pod
+// reported as terminal while its job was still running.
+func TestSqueueStatusArgsAreSelfContained(t *testing.T) {
+args := squeueStatusArgs("227105")
+
+for _, arg := range args {
+if arg != strings.TrimSpace(arg) {
+t.Errorf("argument %q has surrounding whitespace and only works if a shell re-splits it", arg)
+}
+}
+
+joined := strings.Join(args, " ")
+if !strings.Contains(joined, "-j 227105") {
+t.Errorf("expected the job id to follow -j, got %q", joined)
 }
 }


### PR DESCRIPTION
Closes #155 .

The per-job status query passed `"-j "` with a trailing space and the job id as a separate element:

```go
cmd := []string{"--noheader", "-a", "--states=all", "-O", "exit_code,StateCompact", "-j ", jid}
```

That lands as `-j <jid>` only because `Shell: true` joins everything for bash, which splits it again. A `SqueuePath` wrapper that forwards its arguments faithfully — what a correctly quoting ssh shim does — makes squeue see an empty job id:

```
squeue: error: Invalid job id:
```

The poll then returns nothing, the state regex matches nothing, and the pod is reported terminal seconds after submission while its job is still running. With the missing-status-file fallback on top, it reports **Succeeded**; we watched an OOM-killed job surface that way.

## Change

Pass `-j` and the job id as two arguments, and move the query into `squeueStatusArgs` so its shape is testable. No behaviour change under `Shell: true` — bash rejoins them identically.

The comments explaining `exit_code` over `DerivedEC` and `--states=all` move onto the helper.

## Testing

`TestSqueueStatusArgsAreSelfContained` asserts no argument carries surrounding whitespace, and that the job id follows `-j`.

Found while deploying the SSH shadow (interlink-hq/interLink#550) against three HPC sites. Related: #153, the same class of bug in the resource probe — together they are why sites end up forwarding arguments unquoted.
